### PR TITLE
Uses ES suggested version of Java

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -43,10 +43,10 @@ RUN aws --version;
 
 # install java
 # Server JRE (https://goo.gl/2MsPoh)
-ENV JAVA_VERSION "1.8.144"
+ENV JAVA_VERSION "1.8.131"
 RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | \
-    JABBA_COMMAND="install $JAVA_VERSION" bash
-ENV JAVA_HOME /root/.jabba/jdk/$JAVA_VERSION
+    JABBA_COMMAND="install zulu@$JAVA_VERSION -o /jdk" bash
+ENV JAVA_HOME /jdk
 ENV PATH $JAVA_HOME/bin:$PATH
-  
+
 COPY build.js /build.js


### PR DESCRIPTION
Had to move to Zulu's OpenJDK as 1.8 is no longer available. We're also using OpenJDK in our ES Docker builds